### PR TITLE
Support formatter plugins

### DIFF
--- a/lib/fluent/plugin/out_file_with_fix_path.rb
+++ b/lib/fluent/plugin/out_file_with_fix_path.rb
@@ -19,8 +19,8 @@ module Fluent
       conf['buffer_path'] ||= @path
       super
 
-      conf['format'] = @format
-      @formatter = TextFormatter.create(conf)
+      @formatter = Plugin.new_formatter(@format)
+      @formatter.configure(conf)
 
     end
 


### PR DESCRIPTION
Fluentd 0.10.58 or later supports Formatter plugins in out plugins.
see: https://github.com/fluent/fluentd/blob/v0.10/ChangeLog#L27
