### PR TITLE
modify constant

### DIFF
--- a/lib/fluent/plugin/out_file_with_fix_path.rb
+++ b/lib/fluent/plugin/out_file_with_fix_path.rb
@@ -4,6 +4,8 @@ module Fluent
     config_param :path, :string
     config_param :format, :string, :default => 'out_file'
 
+    FILE_PERMISSION = 0644
+
     def initialize
       require 'time'
       super
@@ -30,7 +32,7 @@ module Fluent
 
     def write(chunk)
       FileUtils.mkdir_p File.dirname(@path)
-      File.open(@path, "a", DEFAULT_FILE_PERMISSION) do |f|
+      File.open(@path, "a", FILE_PERMISSION) do |f|
         chunk.write_to(f)
       end
     end


### PR DESCRIPTION
I found a bug.

I want to use the Fluentd v0.14.22.
"DEFAULT_FILE_PERMISSION" is not found in above version

please review it.

[0.12.22]
http://www.rubydoc.info/gems/fluentd/0.12.22/Fluent

[0.14.22]
http://www.rubydoc.info/gems/fluentd/0.14.22/Fluent